### PR TITLE
Reduce iterations for private key encryption

### DIFF
--- a/Assets/ComethSDK/Scripts/Tools/Constants.cs
+++ b/Assets/ComethSDK/Scripts/Tools/Constants.cs
@@ -42,7 +42,7 @@ namespace ComethSDK.Scripts.Tools
 
 		public static readonly string DEFAULT_DATA_FOLDER = "connect";
 		public static readonly string DEFAULT_ENCRYPTION_SALT = "COMETH-CONNECT";
-		public static readonly int PBKDF2_ITERATIONS = 1000000;
+		public static readonly int PBKDF2_ITERATIONS = 100000;
 
 		public static readonly string SAFE_SENTINEL_OWNERS = "0x1";
 

--- a/Assets/ComethSDK/Scripts/Types/EncryptionData.cs
+++ b/Assets/ComethSDK/Scripts/Types/EncryptionData.cs
@@ -4,5 +4,6 @@
 	{
 		public string encryptedPrivateKey { get; set; }
 		public string iv { get; set; }
+		public int iterations { get; set; }
 	}
 }


### PR DESCRIPTION
This PR updates the number of iterations needed to encrypt and decrypt signer private key, reducing the duration of creation / connection to the wallet.
When connecting to an existing wallet on Cosmik Battle, because the number of iterations is not in the file, it will decrypt using legacy number of iterations and rewrite the new number in the file.